### PR TITLE
Fix code scanning alert no. 30: Missing origin verification in `postMessage` handler

### DIFF
--- a/src/api/telemetry/WebSocketWorker.js
+++ b/src/api/telemetry/WebSocketWorker.js
@@ -412,8 +412,13 @@ export default function installWorker() {
   const workerBroker = new WorkerToWebSocketMessageBroker(websocket, messageBatcher);
   const websocketBroker = new WebSocketToWorkerMessageBroker(messageBatcher, self);
 
+  const trustedOrigins = ['https://www.example.com']; // Add your trusted origins here
   self.addEventListener('message', (message) => {
-    workerBroker.routeMessageToHandler(message);
+    if (trustedOrigins.includes(message.origin)) {
+      workerBroker.routeMessageToHandler(message);
+    } else {
+      console.warn('Untrusted origin:', message.origin);
+    }
   });
   websocket.registerMessageCallback((data) => {
     websocketBroker.routeMessageToHandler(data);


### PR DESCRIPTION
### Description

In this pull request, changes are made to the WebSocketWorker implementation in the telemetry API. A check is added to ensure that messages received from trusted origins are routed to the message handler. If the message origin is not in the list of trusted origins, a warning will be logged.

- Added a new array `trustedOrigins` containing a list of trusted origins.
- Added a condition to check if the message's origin is in the `trustedOrigins` array before routing the message to the handler. If not trusted, a warning is logged.

These changes enhance the security of the WebSocketWorker by allowing only messages from trusted origins to be processed.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add origin verification to the `postMessage` handler in `WebSocketWorker.js` to ensure messages are only processed from trusted origins.

### Why are these changes being made?

This change addresses a security vulnerability identified by code scanning alert no. 30, which highlighted the lack of origin verification in the `postMessage` handler. By implementing a check against a list of trusted origins, we mitigate the risk of processing potentially malicious messages from untrusted sources.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->